### PR TITLE
Collection Mutations

### DIFF
--- a/Team9Project/src/com/indragie/cmput301as1/CollectionMutation.java
+++ b/Team9Project/src/com/indragie/cmput301as1/CollectionMutation.java
@@ -1,0 +1,62 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+/**
+ * Represents a single mutation to a collection.
+ */
+public abstract class CollectionMutation<T> {
+	/**
+	 * The type of the collection mutation.
+	 */
+	public enum MutationType { 
+		/**
+		 * An object was inserted into a collection.
+		 */
+		INSERT, 
+		/**
+		 * An object was removed from a collection.
+		 */
+		REMOVE, 
+		/**
+		 * An existing object in a collection was replaced with
+		 * a new one.
+		 */
+		UPDATE 
+	}
+	
+	/**
+	 * The type of the collection mutation.
+	 */
+	private MutationType mutationType;
+	
+	/**
+	 * Creates a new instance of {@link CollectionMutation}
+	 * @param mutationType The type of the collection mutation.
+	 */
+	protected CollectionMutation(MutationType mutationType) {
+		this.mutationType = mutationType;
+	}
+	
+	/**
+	 * @return The type of the collection mutation.
+	 */
+	public MutationType getMutationType() {
+		return mutationType;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/ElasticSearchDocumentID.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ElasticSearchDocumentID.java
@@ -17,10 +17,14 @@
 
 package com.indragie.cmput301as1;
 
+import java.io.Serializable;
+
 /**
  * Uniquely identifies an object in an ElasticSearch database.
  */
-public class ElasticSearchDocumentID {
+public class ElasticSearchDocumentID implements Serializable {
+	private static final long serialVersionUID = -1486832517997319621L;
+
 	//================================================================================
 	// Properties
 	//================================================================================

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseClaim.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseClaim.java
@@ -120,6 +120,7 @@ public class ExpenseClaim implements Serializable, ElasticSearchDocument {
 	 * User who created this claim.
 	 */
 	private User user;
+	
 	/**
 	 * Approvers comments.
 	 */

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimListActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimListActivity.java
@@ -19,7 +19,6 @@ package com.indragie.cmput301as1;
 
 
 import java.util.Comparator;
-import java.util.List;
 
 import android.app.AlertDialog;
 import android.app.ListActivity;
@@ -39,7 +38,7 @@ import android.widget.Toast;
 /**
  * An activity that presents a list of expense claims.
  */
-public class ExpenseClaimListActivity extends ListActivity implements TypedObserver<List<ExpenseClaim>> {
+public class ExpenseClaimListActivity extends ListActivity implements TypedObserver<CollectionMutation<ExpenseClaim>> {
 	//================================================================================
 	// Constants
 	//================================================================================
@@ -321,8 +320,8 @@ public class ExpenseClaimListActivity extends ListActivity implements TypedObser
 	//================================================================================
 
 	@Override
-	public void update(TypedObservable<List<ExpenseClaim>> o, List<ExpenseClaim> claims) {
-		setListAdapter(new ExpenseClaimArrayAdapter(this, claims));
+	public void update(TypedObservable<CollectionMutation<ExpenseClaim>> observable, CollectionMutation<ExpenseClaim> mutation) {
+		setListAdapter(new ExpenseClaimArrayAdapter(this, listModel.getItems()));
 	}
 
 }

--- a/Team9Project/src/com/indragie/cmput301as1/InsertionCollectionMutation.java
+++ b/Team9Project/src/com/indragie/cmput301as1/InsertionCollectionMutation.java
@@ -1,0 +1,59 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+/**
+ * Represents a mutation to a collection where an object was inserted.
+ * @param <T> The type of the object that was inserted.
+ */
+public class InsertionCollectionMutation<T> extends CollectionMutation<T> {
+	/**
+	 * The index at which the object was inserted.
+	 */
+	private int index;
+	
+	/**
+	 * The object that was inserted.
+	 */
+	private T object;
+	
+	/**
+	 * Creates a new instance of {@link InsertionCollectionMutation<T>}
+	 * @param index The index at which the object was inserted.
+	 * @param object The object that was inserted.
+	 */
+	public InsertionCollectionMutation(int index, T object) {
+		super(MutationType.INSERT);
+		this.index = index;
+		this.object = object;
+	}
+	
+	/**
+	 * @return The index at which the object was inserted.
+	 */
+	public int getIndex() {
+		return index;
+	}
+	
+	/**
+	 * @return The object that was inserted.
+	 */
+	public T getObject() {
+		return object;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/ManageTagsActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ManageTagsActivity.java
@@ -16,8 +16,6 @@
  */
 package com.indragie.cmput301as1;
 
-import java.util.List;
-
 import android.app.ListActivity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -34,7 +32,7 @@ import android.widget.AdapterView;
  * Can direct user to activities for adding or editing tags. 
  * Allows user to remove existing tags. 
  */
-public class ManageTagsActivity extends ListActivity implements TypedObserver<List<Tag>>{
+public class ManageTagsActivity extends ListActivity implements TypedObserver<CollectionMutation<Tag>>{
 
 	//================================================================================
 	// Constants
@@ -142,8 +140,8 @@ public class ManageTagsActivity extends ListActivity implements TypedObserver<Li
 	}
 	
 	@Override
-	public void update(TypedObservable<List<Tag>> o, List<Tag> tags) {
-		setListAdapter(new TagArrayAdapter(this, tags));
+	public void update(TypedObservable<CollectionMutation<Tag>> observable, CollectionMutation<Tag> mutation) {
+		setListAdapter(new TagArrayAdapter(this, listModel.getItems()));
 	}
 	
 	@Override

--- a/Team9Project/src/com/indragie/cmput301as1/RemovalCollectionMutation.java
+++ b/Team9Project/src/com/indragie/cmput301as1/RemovalCollectionMutation.java
@@ -1,0 +1,60 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+/**
+ * Represents a mutation to a collection where an object was
+ * removed from the collection.
+ * @param <T> The type of the object that was removed.
+ */
+public class RemovalCollectionMutation<T> extends CollectionMutation<T> {
+	/**
+	 * The index of the object that was removed.
+	 */
+	private int index;
+	
+	/**
+	 * The object that was removed.
+	 */
+	private T object;
+	
+	/**
+	 * Creates a new instance of {@link RemovalCollectionMutation<T>}
+	 * @param index The index of the object that was removed.
+	 * @param object The object that was removed.
+	 */
+	public RemovalCollectionMutation(int index, T object) {
+		super(MutationType.REMOVE);
+		this.index = index;
+		this.object = object;
+	}
+	
+	/**
+	 * @return The index of the object that was removed.
+	 */
+	public int getIndex() {
+		return index;
+	}
+	
+	/**
+	 * @return The object that was removed.
+	 */
+	public T getObject() {
+		return object;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/TagAddToClaimActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/TagAddToClaimActivity.java
@@ -17,8 +17,6 @@
 
 package com.indragie.cmput301as1;
 
-import java.util.List;
-
 import android.app.ListActivity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -29,7 +27,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 
-public class TagAddToClaimActivity extends ListActivity implements TypedObserver<List<Tag>>{
+public class TagAddToClaimActivity extends ListActivity implements TypedObserver<CollectionMutation<Tag>>{
 
 	//================================================================================
 	// Constants
@@ -137,8 +135,8 @@ public class TagAddToClaimActivity extends ListActivity implements TypedObserver
 	}
 	
 	@Override
-	public void update(TypedObservable<List<Tag>> o, List<Tag> tags) {
-		setListAdapter(new TagArrayAdapter(this, tags));
+	public void update(TypedObservable<CollectionMutation<Tag>> observable, CollectionMutation<Tag> mutation) {
+		setListAdapter(new TagArrayAdapter(this, listModel.getItems()));
 	}
 	
 	/**

--- a/Team9Project/src/com/indragie/cmput301as1/UpdateCollectionMutation.java
+++ b/Team9Project/src/com/indragie/cmput301as1/UpdateCollectionMutation.java
@@ -1,0 +1,69 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+public class UpdateCollectionMutation<T> extends CollectionMutation<T> {
+	/**
+	 * The index of the object that was updated.
+	 */
+	private int index;
+	
+	/**
+	 * The old object (pre-update)
+	 */
+	private T oldObject;
+	
+	/**
+	 * The new object (post-update)
+	 */
+	private T newObject;
+	
+	/**
+	 * Creates a new instance of {@link UpdateCollectionMutation<T>}
+	 * @param index The index of the object that was updated.
+	 * @param oldObject The old object (pre-update)
+	 * @param newObject The new object (post-update)
+	 */
+	public UpdateCollectionMutation(int index, T oldObject, T newObject) {
+		super(MutationType.UPDATE);
+		this.index = index;
+		this.oldObject = oldObject;
+		this.newObject = newObject;
+	}
+	
+	/**
+	 * @return The index of the object that was updated.
+	 */
+	public int getIndex() {
+		return index;
+	}
+	
+	/**
+	 * @return The old object (pre-update)
+	 */
+	public T getOldObject() {
+		return oldObject;
+	}
+	
+	/**
+	 * @return The new object (post-update)
+	 */
+	public T getNewObject() {
+		return newObject;
+	}
+}

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ListModelTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ListModelTests.java
@@ -155,6 +155,12 @@ public class ListModelTests extends ActivityInstrumentationTestCase2<ExpenseClai
 		listModel.set(1, claim3);
 		assertEquals(claim1, listModel.getItems().get(0));
 		assertEquals(claim3, listModel.getItems().get(1));
+		
+		CollectionMutation<ExpenseClaim> mutation = observer.getMutation();
+		assertEquals(CollectionMutation.MutationType.UPDATE, mutation.getMutationType());
+		assertEquals(claim2, ((UpdateCollectionMutation<ExpenseClaim>)mutation).getOldObject());
+		assertEquals(claim3, ((UpdateCollectionMutation<ExpenseClaim>)mutation).getNewObject());
+		assertEquals(1, ((UpdateCollectionMutation<ExpenseClaim>)mutation).getIndex());
 	}
 	
 	public void testPersistence() {


### PR DESCRIPTION
This modifies `ListModel<T>` so that it notifies its observers of individual changes to the list, represented using instances of subclasses of the `CollectionMutation<T>` abstract class. This allows observers to take action based on individual insertions/removals/updates to the collection. This is intended to be used with our ElasticSearch functionality, so that a manager of some sort can observe the shared `ListModel<ExpenseClaim>` instance and push changes to ElasticSearch when claims are added, removed, or updated.

There is a bit of messiness when it comes to sorting (see the `TODO`s in the code) because the indices of the items change once they have been sorted. The current workaround is to notify the observers before sorting takes place (so that the original indices are still valid), which should hold up for the time being.
