### PR TITLE
ElasticSearch Integration

### DIFF
--- a/Team9Project/gen/com/indragie/cmput301as1/R.java
+++ b/Team9Project/gen/com/indragie/cmput301as1/R.java
@@ -114,44 +114,44 @@ public final class R {
         public static final int expense_item_edit=0x7f080006;
     }
     public static final class string {
-        public static final int TagName=0x7f06003c;
-        public static final int action_accept=0x7f06003e;
+        public static final int TagName=0x7f06003d;
+        public static final int action_accept=0x7f06003f;
         /**  ExpenseClaimListActivity 
          */
         public static final int action_add_claim=0x7f060012;
-        public static final int action_add_destination=0x7f06001e;
-        public static final int action_add_item=0x7f06001f;
-        public static final int action_add_tag=0x7f060039;
+        public static final int action_add_destination=0x7f06001f;
+        public static final int action_add_item=0x7f060020;
+        public static final int action_add_tag=0x7f06003a;
         public static final int action_confirm_prefix=0x7f060002;
         public static final int action_delete=0x7f060001;
         public static final int action_delete_claim_confirm=0x7f060013;
-        public static final int action_delete_dest_confirm=0x7f060024;
-        public static final int action_delete_item_confirm=0x7f060025;
-        public static final int action_delete_tag_confirm=0x7f060026;
-        public static final int action_edit=0x7f06003b;
-        public static final int action_email=0x7f060020;
-        public static final int action_manage_tags=0x7f06003a;
-        public static final int action_mark_approved=0x7f060023;
-        public static final int action_mark_returned=0x7f060022;
-        public static final int action_mark_submitted=0x7f060021;
-        public static final int action_new_tag=0x7f06003d;
+        public static final int action_delete_dest_confirm=0x7f060025;
+        public static final int action_delete_item_confirm=0x7f060026;
+        public static final int action_delete_tag_confirm=0x7f060027;
+        public static final int action_edit=0x7f06003c;
+        public static final int action_email=0x7f060021;
+        public static final int action_manage_tags=0x7f06003b;
+        public static final int action_mark_approved=0x7f060024;
+        public static final int action_mark_returned=0x7f060023;
+        public static final int action_mark_submitted=0x7f060022;
+        public static final int action_new_tag=0x7f06003e;
         public static final int action_set_incomplete=0x7f06000f;
-        public static final int action_sort_claim=0x7f06002b;
-        public static final int alert_submit_message=0x7f060034;
-        public static final int alert_submit_title=0x7f060033;
+        public static final int action_sort_claim=0x7f06002c;
+        public static final int alert_submit_message=0x7f060035;
+        public static final int alert_submit_title=0x7f060034;
         public static final int amount=0x7f06000d;
-        public static final int amount_placeholder=0x7f060031;
+        public static final int amount_placeholder=0x7f060032;
         /**  General 
          */
         public static final int app_name=0x7f060000;
-        public static final int approver=0x7f06002f;
+        public static final int approver=0x7f060030;
         /**  EditingActivity 
          */
         public static final int cancel_label=0x7f060010;
         /**  ExpenseItem 
          */
         public static final int category=0x7f06000c;
-        public static final int comments=0x7f060030;
+        public static final int comments=0x7f060031;
         public static final int date=0x7f06000e;
         public static final int dates=0x7f060004;
         /**  ExpenseClaim 
@@ -159,46 +159,47 @@ public final class R {
         public static final int description=0x7f060003;
         /**  ExpenseClaimDetailController 
          */
-        public static final int destinations_title=0x7f060035;
+        public static final int destinations_title=0x7f060036;
         /**  ExpenseClaim{Detail,Add}Activity 
          */
-        public static final int detail_title=0x7f060019;
+        public static final int detail_title=0x7f06001a;
         public static final int done_label=0x7f060011;
-        public static final int end_label=0x7f06001d;
+        public static final int end_label=0x7f06001e;
         public static final int expense_items=0x7f060006;
-        public static final int hello_world=0x7f060042;
+        public static final int hello_world=0x7f060043;
         public static final int incomplete=0x7f06000b;
-        public static final int items_title=0x7f060037;
-        public static final int name_hint=0x7f06001a;
+        public static final int items_title=0x7f060038;
+        public static final int load_fail_error=0x7f060019;
+        public static final int name_hint=0x7f06001b;
         public static final int no_destinations=0x7f060015;
         public static final int no_expenses=0x7f060014;
-        public static final int sort_order=0x7f06002d;
-        public static final int sort_type=0x7f06002c;
-        public static final int start_label=0x7f06001c;
+        public static final int sort_order=0x7f06002e;
+        public static final int sort_type=0x7f06002d;
+        public static final int start_label=0x7f06001d;
         public static final int status=0x7f060005;
         public static final int status_approved=0x7f060009;
         public static final int status_in_progress=0x7f060007;
         public static final int status_returned=0x7f06000a;
         public static final int status_submitted=0x7f060008;
-        public static final int tags_title=0x7f060036;
-        public static final int title_activity_add_tag=0x7f06003f;
-        public static final int title_activity_edit_tag=0x7f060040;
+        public static final int tags_title=0x7f060037;
+        public static final int title_activity_add_tag=0x7f060040;
+        public static final int title_activity_edit_tag=0x7f060041;
         /**  ManageTagsActivity 
          */
-        public static final int title_activity_manage_tags=0x7f060038;
+        public static final int title_activity_manage_tags=0x7f060039;
         /**   Tag{Add,Edit}ToClaimActivity 
          */
-        public static final int title_activity_tag_edit_to_claim=0x7f060043;
+        public static final int title_activity_tag_edit_to_claim=0x7f060044;
         /**  ExpenseClaimSortActivity 
          */
-        public static final int title_activity_tag_list=0x7f060041;
-        public static final int toast_receipt_deleted=0x7f060029;
-        public static final int toast_receipt_failed=0x7f060028;
-        public static final int toast_receipt_nonexistent=0x7f06002a;
-        public static final int toast_receipt_success=0x7f060027;
-        public static final int total_label=0x7f060032;
-        public static final int travel_reason_hint=0x7f06001b;
-        public static final int user=0x7f06002e;
+        public static final int title_activity_tag_list=0x7f060042;
+        public static final int toast_receipt_deleted=0x7f06002a;
+        public static final int toast_receipt_failed=0x7f060029;
+        public static final int toast_receipt_nonexistent=0x7f06002b;
+        public static final int toast_receipt_success=0x7f060028;
+        public static final int total_label=0x7f060033;
+        public static final int travel_reason_hint=0x7f06001c;
+        public static final int user=0x7f06002f;
         public static final int user_alert_error=0x7f060018;
         public static final int user_alert_message=0x7f060017;
         public static final int user_alert_title=0x7f060016;

--- a/Team9Project/res/values/strings.xml
+++ b/Team9Project/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="user_alert_title">Welcome, new user!</string>
     <string name="user_alert_message">Please enter your name.</string>
     <string name="user_alert_error">You must enter a name.</string>
+    <string name="load_fail_error">Failed to load expense claims from server.</string>
 
     <!-- ExpenseClaim{Detail,Add}Activity -->
     <string name="detail_title">Detail</string>

--- a/Team9Project/src/com/indragie/cmput301as1/ElasticSearchAPIClient.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ElasticSearchAPIClient.java
@@ -340,15 +340,14 @@ public class ElasticSearchAPIClient {
 		@Override
 		public List<T> modelFromResponse(Response response) {
 			JsonParser parser = new JsonParser();
-			JsonElement rootElement;
 			try {
-				rootElement = parser.parse(response.body().string());
+				ArrayList<T> models = new ArrayList<T>();
+				JsonElement rootElement = parser.parse(response.body().string());
 				if (rootElement.isJsonObject()) {
 					JsonElement outerHitsElement = rootElement.getAsJsonObject().get("hits");
 					if (outerHitsElement.isJsonObject()) {
 						JsonElement hitsElement = outerHitsElement.getAsJsonObject().get("hits");
 						if (hitsElement.isJsonArray()) {
-							ArrayList<T> models = new ArrayList<T>();
 							for (JsonElement element : hitsElement.getAsJsonArray()) {
 								if (element.isJsonObject()) {
 									JsonObject docObject = element.getAsJsonObject();
@@ -359,10 +358,10 @@ public class ElasticSearchAPIClient {
 									}
 								}
 							}
-							return models;
 						}
 					}
 				}
+				return models;
 			} catch (JsonSyntaxException e) {
 				e.printStackTrace();
 			} catch (IOException e) {

--- a/Team9Project/src/com/indragie/cmput301as1/ElasticSearchAPIClient.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ElasticSearchAPIClient.java
@@ -350,11 +350,13 @@ public class ElasticSearchAPIClient {
 						if (hitsElement.isJsonArray()) {
 							for (JsonElement element : hitsElement.getAsJsonArray()) {
 								if (element.isJsonObject()) {
-									JsonObject docObject = element.getAsJsonObject();
-									JsonElement sourceElement = docObject.get("_source");
-									T model = gson.fromJson(sourceElement, documentType);
-									if (model != null) {
-										models.add(model);
+									JsonElement sourceElement = element.getAsJsonObject().get("_source");
+									if (sourceElement.isJsonObject()) {
+										JsonElement docElement = sourceElement.getAsJsonObject().get("doc");
+										T model = gson.fromJson(docElement, documentType);
+										if (model != null) {
+											models.add(model);
+										}
 									}
 								}
 							}

--- a/Team9Project/src/com/indragie/cmput301as1/ElasticSearchQueue.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ElasticSearchQueue.java
@@ -111,8 +111,9 @@ public class ElasticSearchQueue<T> implements TypedObserver<NetworkInfo.State> {
 	//================================================================================
 
 	/**
-	 * adds a call to the stack. Then attempts to execute it.
-	 * @param APICall<T>
+	 * Adds an API call to the queue for later execution.
+	 * @param call The call to enqueue.
+	 * @param callback Optional callback to be called after execution.
 	 */
 	public void enqueueCall(ElasticSearchAPIClient.APICall<T> call, ElasticSearchAPIClient.APICallback<T> callback) {
 		queue.add(new QueueItem(call, callback));
@@ -120,7 +121,7 @@ public class ElasticSearchQueue<T> implements TypedObserver<NetworkInfo.State> {
 	}
 
 	/**
-	 * checks for APICalls in the stack and for network connection then executes the APICall
+	 * Attemtps to execute the next API call in the queue, if there is one.
 	 */
 	private void attemptNextAPICall() {
 		if (requestExecuting.get() 

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseClaim.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseClaim.java
@@ -148,7 +148,6 @@ public class ExpenseClaim implements Serializable, ElasticSearchDocument {
 		this.status = status;
 		this.creationDate = new Date();
 		this.user = user;
-		this.approver = new User("", "");
 	}
 
 	//================================================================================

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimDetailActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimDetailActivity.java
@@ -227,12 +227,13 @@ public class ExpenseClaimDetailActivity extends ListActivity implements TypedObs
 		userField.append(claim.getUser().getName());
 
 		approverField = (TextView)headerView.findViewById(R.id.tv_approver);
-		approverField.append(claim.getApprover().getName());
-
+		User approver = claim.getApprover();
+		if (approver != null) {
+			approverField.append(approver.getName());
+		}
 
 		comments = (EditText)headerView.findViewById(R.id.et_comments);
 		comments.setText(claim.getComments());
-
 
 		getListView().addHeaderView(headerView);
 	}

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimListActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimListActivity.java
@@ -31,6 +31,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.SparseArray;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -186,8 +187,34 @@ public class ExpenseClaimListActivity extends ListActivity implements TypedObser
 	 */
 	@SuppressWarnings("unchecked")
 	private void onManageTagsResult(Intent data) {
-		ArrayList<ExpenseClaim> claimList = (ArrayList<ExpenseClaim>)data.getSerializableExtra(ManageTagsActivity.CLAIM_LIST);
-		listModel.replace(claimList);
+		ArrayList<ManageTagsActivity.TagMutation> mutations =
+				(ArrayList<ManageTagsActivity.TagMutation>)data.getSerializableExtra(ManageTagsActivity.EXTRA_TAG_MUTATIONS);
+		SparseArray<ExpenseClaim> modifiedClaims = new SparseArray<ExpenseClaim>();
+		
+		for (ManageTagsActivity.TagMutation mutation : mutations) {
+			Tag tag = mutation.getOldTag();
+			int i = 0;
+			for (ExpenseClaim claim : listModel.getItems()) {
+				if (!claim.hasTag(tag)) continue;
+				
+				switch (mutation.getMutationType()) {
+				case DELETE:
+					claim.removeTag(tag);
+					break;
+				case EDIT:
+					int tagIndex = claim.getTags().indexOf(tag);
+					claim.setTag(tagIndex, mutation.getNewTag());
+					break;
+				}
+				
+				modifiedClaims.append(i, claim);
+				i++;
+			}
+		}
+		
+		for (int i = 0; i < modifiedClaims.size(); i++) {
+			listModel.set(modifiedClaims.keyAt(i), modifiedClaims.valueAt(i));
+		}
 	}
 
 	@Override

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimListActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseClaimListActivity.java
@@ -115,7 +115,13 @@ public class ExpenseClaimListActivity extends ListActivity implements TypedObser
 
 			@Override
 			public void onFailure(Request request, Response response, IOException e) {
-				Toast.makeText(context, R.string.load_fail_error, Toast.LENGTH_LONG).show();
+				runOnUiThread(new Runnable() {
+					@Override
+					public void run() {
+						Toast.makeText(context, R.string.load_fail_error, Toast.LENGTH_LONG).show();
+					}
+				});
+				
 			}
 		});
 	}
@@ -229,7 +235,6 @@ public class ExpenseClaimListActivity extends ListActivity implements TypedObser
 	 */
 	private void startManageTagsActivity() {
 		Intent manageTagsIntent = new Intent(this, ManageTagsActivity.class);
-		manageTagsIntent.putExtra(ManageTagsActivity.CLAIM_LIST, new ArrayList<ExpenseClaim>(listModel.getItems()));
 		startActivityForResult(manageTagsIntent, MANAGE_TAGS_REQUEST);
 	}
 	

--- a/Team9Project/src/com/indragie/cmput301as1/ManageTagsActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ManageTagsActivity.java
@@ -17,6 +17,7 @@
 package com.indragie.cmput301as1;
 
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 import android.content.Intent;
@@ -32,6 +33,93 @@ import android.view.MenuItem;
  */
 
 public class ManageTagsActivity extends TagAddToClaimActivity{
+	//================================================================================
+	// Classes
+	//================================================================================
+	
+	/**
+	 * Class that encapsulates a mutation to a tag.
+	 */
+	public static class TagMutation implements Serializable {
+		private static final long serialVersionUID = -7792735815468100896L;
+		/**
+		 * The type of mutation that occurred.
+		 */
+		public enum MutationType {
+			/**
+			 * Tag was deleted. {@link ChangeType#oldTag} will contain the
+			 * tag that was deleted, and {@link ChangeType#newTag} will be
+			 * null.
+			 */
+			DELETE,
+			/**
+			 * Tag was edited. {@link ChangeType#oldTag} will contain the
+			 * original tag, and {@link ChangeType#newTag} will contain the
+			 * modified tag.
+			 */
+			EDIT
+		}
+		
+		//================================================================================
+		// Properties
+		//================================================================================
+		
+		/**
+		 * The type of mutation that occurred.
+		 */
+		private MutationType mutationType;
+		
+		/**
+		 * The previous version of the tag.
+		 */
+		private Tag oldTag;
+		
+		/**
+		 * The new version of the tag.
+		 */
+		private Tag newTag;
+		
+		//================================================================================
+		// Constructors
+		//================================================================================
+		
+		/**
+		 * Creates a new instance of {@link TagMutation}
+		 * @param mutationType The type of mutation that occurred.
+		 * @param oldTag The previous version of the tag.
+		 * @param newTag The new version of the tag.
+		 */
+		public TagMutation(MutationType mutationType, Tag oldTag, Tag newTag) {
+			this.mutationType = mutationType;
+			this.oldTag = oldTag;
+			this.newTag = newTag;
+		}
+		
+		//================================================================================
+		// Accessors
+		//================================================================================
+		
+		/**
+		 * @return The type of mutation that occurred.
+		 */
+		public MutationType getMutationType() {
+			return mutationType;
+		}
+		
+		/**
+		 * @return The previous version of the tag.
+		 */
+		public Tag getOldTag() {
+			return oldTag;
+		}
+		
+		/**
+		 * @return The new version of the tag.
+		 */
+		public Tag getNewTag() {
+			return newTag;
+		}
+	}
 
 	//================================================================================
 	// Constants
@@ -41,15 +129,16 @@ public class ManageTagsActivity extends TagAddToClaimActivity{
 
 	public static final String EXTRA_TAG = "com.indragie.cmput301as1.EXTRA_TAG";
 	
-	public static final String CLAIM_LIST = "com.indragie.cmput301as1.CLAIM_LIST";
+	public static final String EXTRA_TAG_MUTATIONS = "com.indragie.cmput301as1.TAG_MUTATIONS";
 	
 	//================================================================================
 	// Properties
 	//================================================================================
 	
-	private ArrayList<ExpenseClaim> claimList;
-	
-	Boolean listChanged;
+	/**
+	 * Used to store pending mutations to the tags.
+	 */
+	private ArrayList<TagMutation> mutations = new ArrayList<TagMutation>();
 	
 	//================================================================================
 	// Activity Callbacks
@@ -59,14 +148,8 @@ public class ManageTagsActivity extends TagAddToClaimActivity{
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		
 		setUpActionBarAndModel();
-		
-		Intent intent = getIntent();
-		
-		claimList = (ArrayList<ExpenseClaim>)intent.getSerializableExtra(CLAIM_LIST);
-		listChanged = false;
-		
+	
 		final ActionMode.Callback clickCallback = new ActionMode.Callback() {
 			@Override
 			public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
@@ -77,9 +160,8 @@ public class ManageTagsActivity extends TagAddToClaimActivity{
 						return true;
 					case R.id.action_delete:
 						Tag tag = getTagAt(pressedItemIndex);
-						deleteTagInClaims(tag);
-						
 						listModel.remove(pressedItemIndex);
+						mutations.add(new TagMutation(TagMutation.MutationType.DELETE, tag, null));
 						mode.finish();
 						return true;
 					default:
@@ -124,12 +206,8 @@ public class ManageTagsActivity extends TagAddToClaimActivity{
 	@Override
 	protected void onHome() {
 		Intent intent = new Intent();
-		if(listChanged) {
-			intent.putExtra(CLAIM_LIST, claimList);
-			setResult(RESULT_OK, intent);
-		} else {
-			setResult(RESULT_CANCELED, intent);
-		}
+		intent.putExtra(EXTRA_TAG_MUTATIONS, mutations);
+		setResult(RESULT_OK, intent);
 		finish();
 	}
 	
@@ -153,38 +231,7 @@ public class ManageTagsActivity extends TagAddToClaimActivity{
 	private void onEditTag(Intent data) {
 		Tag newTag = (Tag)data.getSerializableExtra(TagAddActivity.ADDED_TAG);
 		Tag oldTag = getTagAt(pressedItemIndex);
-		
 		listModel.set(pressedItemIndex, newTag);
-		updateTagsInClaims(oldTag, newTag);
+		mutations.add(new TagMutation(TagMutation.MutationType.EDIT, oldTag, newTag));
 	}
-	
-	/**
-	 * Update the old tag with the new tag in claims that are returned or in progress.
-	 * @param oldTag The old tag to update.
-	 * @param newTag The new tag.
-	 */
-	private void updateTagsInClaims(Tag oldTag, Tag newTag) {
-		for (ExpenseClaim claim: claimList) {
-			if(claim.hasTag(oldTag)) {
-				listChanged = true;
-				claim.setTag(oldTag, newTag);
-			}
-		
-		}
-
-	}
-	
-	/**
-	 * Deletes the removed tag in claims that are returned or in progress.
-	 * @param tag Tag to remove in claims.
-	 */
-	private void deleteTagInClaims(Tag tag) {
-		for(ExpenseClaim claim: claimList) {
-			if(claim.hasTag(tag)) {
-				listChanged = true;
-				claim.removeTag(tag);
-			}
-		}
-	}
-	
 }

--- a/Team9Project/src/com/indragie/cmput301as1/NetworkStateListener.java
+++ b/Team9Project/src/com/indragie/cmput301as1/NetworkStateListener.java
@@ -41,7 +41,7 @@ public class NetworkStateListener extends BroadcastReceiver {
 	 * The observable that observers use to receive updates when the 
 	 * network state changes.
 	 */
-	private TypedObservable<NetworkInfo.State> observable;
+	private TypedObservable<NetworkInfo.State> observable = new TypedObservable<NetworkInfo.State>();
 	
 	//================================================================================
 	// Constructors

--- a/Team9Project/src/com/indragie/cmput301as1/Session.java
+++ b/Team9Project/src/com/indragie/cmput301as1/Session.java
@@ -203,10 +203,10 @@ public class Session implements TypedObserver<CollectionMutation<ExpenseClaim>> 
 			final ElasticSearchAPIClient.APICallback<List<ExpenseClaim>> callback, 
 			final ListModel<ExpenseClaim> listModel) {
 		
+		final Handler mainHandler = new Handler(context.getMainLooper());
 		pullQueue.enqueueCall(call, new ElasticSearchAPIClient.APICallback<List<ExpenseClaim>>() {
 			@Override
 			public void onSuccess(Response response, final List<ExpenseClaim> results) {
-				Handler mainHandler = new Handler(context.getMainLooper());
 				mainHandler.post(new Runnable() {
 					@Override
 					public void run() {

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ElasticSearchAPIClientTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ElasticSearchAPIClientTests.java
@@ -107,7 +107,7 @@ public class ElasticSearchAPIClientTests extends TestCase
 	public void testSearch() throws InterruptedException, RequestFailedException, IOException {
 		MockResponse response = new MockResponse()
 			.addHeader("Content-Type", "application/json; charset=utf-8")
-			.setBody("{\"took\":0,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"failed\":0},\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"test\",\"_type\":\"doc\",\"_id\":\"1\",\"_score\":1.0,\"_source\":{\"name\":\"Indragie Karunaratne\",\"year\":3}}]}}");
+			.setBody("{\"took\":0,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"failed\":0},\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"test\",\"_type\":\"doc\",\"_id\":\"1\",\"_score\":1.0,\"_source\":{\"doc\": { \"name\":\"Indragie Karunaratne\",\"year\":3}}}]}}");
 		server.enqueue(response);
 		
 		TestDocument document = new TestDocument("Indragie Karunaratne", 3);


### PR DESCRIPTION
Integrates ElasticSearch with the rest of the app. Adding/removing/editing expense claims, as well as managing tags will now synchronize changes to ElasticSearch. The `ExpenseClaim` objects are linked to their corresponding `User`. The `User` objects are now created using a device-specific identifier that stays constant until the device is wiped. That means that even if the user deletes and reinstalls the app, the app will re-download all of their existing data.
