### PR TITLE
ElasticSearch Support for Receipts

### DIFF
--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
@@ -163,7 +163,7 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 	 * @param receiptPath Uri of a receipt image.
 	 */
 	public void setReceiptUri(Uri receiptUri) {
-		this.receiptUriString = receiptUri.toString();
+		this.receiptUriString = (receiptUri == null) ? null : receiptUri.toString();
 	}
 	
 	/**

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
@@ -80,7 +80,6 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 		this.category = category;
 		this.amount = amount;
 		this.date = date;
-		this.incomplete = false;
 	}
 
 	//================================================================================

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
@@ -22,6 +22,8 @@ import java.util.Date;
 
 import org.joda.money.Money;
 
+import android.net.Uri;
+
 /**
  * Model object representing a single item on an expense claim.
  */
@@ -61,7 +63,7 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 	/**
 	 * String representation of a Uri of a receipt image.
 	 */
-	private String receiptPath;
+	private String receiptUriString;
 	
 	/**
 	 * Incompleteness indicator.
@@ -150,18 +152,19 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 	}
 	
 	/**
-	 * @return String representation of a Uri of a receipt image.
+	 * @return Uri of the receipt image.
 	 */
-	public String getReceiptPath() {
-		return receiptPath;
+	public Uri getReceiptUri() {
+		if (receiptUriString == null) return null;
+		return Uri.parse(receiptUriString);
 	}
 
 	/**
-	 * Sets the string representation of a Uri of a receipt image.
-	 * @param receiptPath String representation of a Uri of a receipt image.
+	 * Sets the Uri of a receipt image.
+	 * @param receiptPath Uri of a receipt image.
 	 */
-	public void setReceiptPath(String receiptPath) {
-		this.receiptPath = receiptPath;
+	public void setReceiptUri(Uri receiptUri) {
+		this.receiptUriString = receiptUri.toString();
 	}
 	
 	/**

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItem.java
@@ -26,8 +26,8 @@ import org.joda.money.Money;
  * Model object representing a single item on an expense claim.
  */
 public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
-	private static final long serialVersionUID = -5923561360068724438L;
-
+	private static final long serialVersionUID = -1106294407274690532L;
+	
 	//================================================================================
 	// Properties
 	//================================================================================
@@ -62,6 +62,7 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 	 * String representation of a Uri of a receipt image.
 	 */
 	private String receiptPath;
+	
 	/**
 	 * Incompleteness indicator.
 	 */
@@ -218,6 +219,7 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 		result = prime * result + ((date == null) ? 0 : date.hashCode());
 		result = prime * result
 				+ ((description == null) ? 0 : description.hashCode());
+		result = prime * result + (incomplete ? 1231 : 1237);
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		return result;
 	}
@@ -250,6 +252,8 @@ public class ExpenseItem implements Serializable, Comparable<ExpenseItem> {
 			if (other.description != null)
 				return false;
 		} else if (!description.equals(other.description))
+			return false;
+		if (incomplete != other.incomplete)
 			return false;
 		if (name == null) {
 			if (other.name != null)

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemAddActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemAddActivity.java
@@ -216,7 +216,7 @@ public class ExpenseItemAddActivity extends Activity {
 			dateField.getDate()
 		);
 		if (receiptFileUri != null) {
-			item.setReceiptPath(receiptFileUri.toString());
+			item.setReceiptUri(receiptFileUri);
 		}
 		item.setIncomplete(incomplete);
 		return item;

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemEditActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemEditActivity.java
@@ -22,7 +22,6 @@ import org.joda.money.Money;
 import android.app.ActionBar;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
 

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemEditActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemEditActivity.java
@@ -68,9 +68,7 @@ public class ExpenseItemEditActivity extends ExpenseItemAddActivity {
 		Intent intent = getIntent();
 		ExpenseItem item = (ExpenseItem)getIntent().getSerializableExtra(EXTRA_EXPENSE_ITEM);
 		editable = intent.getBooleanExtra(EXTRA_EXPENSE_ITEM_EDITABLE, false);
-		if (item.getReceiptPath() != null) {
-			receiptFileUri = Uri.parse(item.getReceiptPath());
-		}
+		receiptFileUri = item.getReceiptUri();
 		incomplete = item.isIncomplete();
 		
 		setTitle(item.getName());

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
@@ -1,0 +1,40 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * Deserializes an {@link ExpenseItem} from JSON.
+ */
+public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem> {
+
+	/* (non-Javadoc)
+	 * @see com.google.gson.JsonDeserializer#deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext)
+	 */
+	@Override
+	public ExpenseItem deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
@@ -32,7 +32,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 
 /**
  * Deserializes an {@link ExpenseItem} from JSON.
@@ -59,13 +58,13 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 		JsonObject obj = json.getAsJsonObject();
 		if (obj == null) return null;
 		
-		String name = getStringIfPossible(obj.get("name"));
-		String description = getStringIfPossible(obj.get("description"));
-		String category = getStringIfPossible(obj.get("category"));
-		boolean incomplete = getBooleanIfPossible(obj.get("incomplete"));
-		JsonObject amountObject = getJsonObjectIfPossible(obj.get("amount"));
-		long time = getLongIfPossible(obj.get("date"));
-		String receiptBase64Str = getStringIfPossible(obj.get("receipt_base64"));
+		String name = JSONHelpers.getStringIfPossible(obj.get("name"));
+		String description = JSONHelpers.getStringIfPossible(obj.get("description"));
+		String category = JSONHelpers.getStringIfPossible(obj.get("category"));
+		boolean incomplete = JSONHelpers.getBooleanIfPossible(obj.get("incomplete"));
+		JsonObject amountObject = JSONHelpers.getJsonObjectIfPossible(obj.get("amount"));
+		long time = JSONHelpers.getLongIfPossible(obj.get("date"));
+		String receiptBase64Str = JSONHelpers.getStringIfPossible(obj.get("receipt_base64"));
 		
 		Money amount = null;
 		if (amountObject != null) {
@@ -90,50 +89,5 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 		}
 		
 		return item;
-	}
-	
-	private static String getStringIfPossible(JsonElement element) {
-		if (element == null) return null;
-		
-		if (element.isJsonPrimitive()) {
-			JsonPrimitive primitive = element.getAsJsonPrimitive();
-			if (primitive.isString()) {
-				return primitive.getAsString();
-			}
-		}
-		return null;
-	}
-	
-	private static boolean getBooleanIfPossible(JsonElement element) {
-		if (element == null) return false;
-		
-		if (element.isJsonPrimitive()) {
-			JsonPrimitive primitive = element.getAsJsonPrimitive();
-			if (primitive.isBoolean()) {
-				return primitive.getAsBoolean();
-			}
-		}
-		return false;
-	}
-	
-	private static long getLongIfPossible(JsonElement element) {
-		if (element == null) return 0;
-		
-		if (element.isJsonPrimitive()) {
-			JsonPrimitive primitive = element.getAsJsonPrimitive();
-			if (primitive.isNumber()) {
-				return primitive.getAsLong();
-			}
-		}
-		return 0;
-	}
-	
-	private static JsonObject getJsonObjectIfPossible(JsonElement element) {
-		if (element == null) return null;
-		
-		if (element.isJsonObject()) {
-			return element.getAsJsonObject();
-		}
-		return null;
 	}
 }

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
@@ -63,7 +63,7 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 		String category = JSONHelpers.getStringIfPossible(obj.get("category"));
 		boolean incomplete = JSONHelpers.getBooleanIfPossible(obj.get("incomplete"));
 		JsonObject amountObject = JSONHelpers.getJsonObjectIfPossible(obj.get("amount"));
-		long time = JSONHelpers.getLongIfPossible(obj.get("date"));
+		JsonElement dateElement = obj.get("date");
 		String receiptBase64Str = JSONHelpers.getStringIfPossible(obj.get("receipt_base64"));
 		
 		Money amount = null;
@@ -71,7 +71,12 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 			amount = context.deserialize(amountObject, Money.class);
 		}
 		
-		ExpenseItem item = new ExpenseItem(name, description, category, amount, new Date(time));
+		Date date = null;
+		if (dateElement != null) {
+			date = context.deserialize(dateElement, Date.class);
+		}
+		
+		ExpenseItem item = new ExpenseItem(name, description, category, amount, date);
 		item.setIncomplete(incomplete);
 		
 		if (receiptBase64Str != null) {

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
@@ -64,7 +64,7 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 		String category = getStringIfPossible(obj.get("category"));
 		boolean incomplete = getBooleanIfPossible(obj.get("incomplete"));
 		JsonObject amountObject = getJsonObjectIfPossible(obj.get("amount"));
-		JsonObject dateObject = getJsonObjectIfPossible(obj.get("date"));
+		long time = getLongIfPossible(obj.get("date"));
 		String receiptBase64Str = getStringIfPossible(obj.get("receipt_base64"));
 		
 		Money amount = null;
@@ -72,12 +72,7 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 			amount = context.deserialize(amountObject, Money.class);
 		}
 		
-		Date date = null;
-		if (dateObject != null) {
-			date = context.deserialize(dateObject, Money.class);
-		}
-		
-		ExpenseItem item = new ExpenseItem(name, description, category, amount, date);
+		ExpenseItem item = new ExpenseItem(name, description, category, amount, new Date(time));
 		item.setIncomplete(incomplete);
 		
 		if (receiptBase64Str != null) {
@@ -119,6 +114,18 @@ public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem
 			}
 		}
 		return false;
+	}
+	
+	private static long getLongIfPossible(JsonElement element) {
+		if (element == null) return 0;
+		
+		if (element.isJsonPrimitive()) {
+			JsonPrimitive primitive = element.getAsJsonPrimitive();
+			if (primitive.isNumber()) {
+				return primitive.getAsLong();
+			}
+		}
+		return 0;
 	}
 	
 	private static JsonObject getJsonObjectIfPossible(JsonElement element) {

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONDeserializer.java
@@ -17,24 +17,116 @@
 
 package com.indragie.cmput301as1;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Date;
+
+import org.joda.money.Money;
+
+import android.net.Uri;
+import android.util.Base64;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 
 /**
  * Deserializes an {@link ExpenseItem} from JSON.
  */
 public class ExpenseItemJSONDeserializer implements JsonDeserializer<ExpenseItem> {
+	/**
+	 * Controller used to generate receipt URIs.
+	 */
+	private ExpenseItemReceiptController receiptController;
 
+	/**
+	 * Creates an instance of {@link ExpenseItemJSONDeserializer}
+	 * @param receiptController Controller used to generate receipt URIs.
+	 */
+	public ExpenseItemJSONDeserializer(ExpenseItemReceiptController receiptController) {
+		this.receiptController = receiptController;
+	}
+	
 	/* (non-Javadoc)
 	 * @see com.google.gson.JsonDeserializer#deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext)
 	 */
 	@Override
 	public ExpenseItem deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-		// TODO Auto-generated method stub
+		JsonObject obj = json.getAsJsonObject();
+		if (obj == null) return null;
+		
+		String name = getStringIfPossible(obj.get("name"));
+		String description = getStringIfPossible(obj.get("description"));
+		String category = getStringIfPossible(obj.get("category"));
+		boolean incomplete = getBooleanIfPossible(obj.get("incomplete"));
+		JsonObject amountObject = getJsonObjectIfPossible(obj.get("amount"));
+		JsonObject dateObject = getJsonObjectIfPossible(obj.get("date"));
+		String receiptBase64Str = getStringIfPossible(obj.get("receipt_base64"));
+		
+		Money amount = null;
+		if (amountObject != null) {
+			amount = context.deserialize(amountObject, Money.class);
+		}
+		
+		Date date = null;
+		if (dateObject != null) {
+			date = context.deserialize(dateObject, Money.class);
+		}
+		
+		ExpenseItem item = new ExpenseItem(name, description, category, amount, date);
+		item.setIncomplete(incomplete);
+		
+		if (receiptBase64Str != null) {
+			Uri receiptUri = receiptController.constructNewReceiptImageUri();
+			byte buffer[] = Base64.decode(receiptBase64Str, Base64.DEFAULT);
+			try {
+				FileOutputStream fos = new FileOutputStream(receiptUri.getPath(), false);
+				fos.write(buffer);
+				fos.flush();
+				fos.close();
+				item.setReceiptUri(receiptUri);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		return item;
+	}
+	
+	private static String getStringIfPossible(JsonElement element) {
+		if (element == null) return null;
+		
+		if (element.isJsonPrimitive()) {
+			JsonPrimitive primitive = element.getAsJsonPrimitive();
+			if (primitive.isString()) {
+				return primitive.getAsString();
+			}
+		}
+		return null;
+	}
+	
+	private static boolean getBooleanIfPossible(JsonElement element) {
+		if (element == null) return false;
+		
+		if (element.isJsonPrimitive()) {
+			JsonPrimitive primitive = element.getAsJsonPrimitive();
+			if (primitive.isBoolean()) {
+				return primitive.getAsBoolean();
+			}
+		}
+		return false;
+	}
+	
+	private static JsonObject getJsonObjectIfPossible(JsonElement element) {
+		if (element == null) return null;
+		
+		if (element.isJsonObject()) {
+			return element.getAsJsonObject();
+		}
 		return null;
 	}
 }

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
@@ -17,9 +17,19 @@
 
 package com.indragie.cmput301as1;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.util.Date;
+
+import org.joda.money.Money;
+
+import android.net.Uri;
+import android.util.Base64;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
@@ -33,6 +43,29 @@ public class ExpenseItemJSONSerializer implements JsonSerializer<ExpenseItem> {
 	 */
 	@Override
 	public JsonElement serialize(ExpenseItem src, Type typeOfSrc, JsonSerializationContext context) {
-		return null;
+		JsonObject obj = new JsonObject();
+		obj.addProperty("name", src.getName());
+		obj.addProperty("description", src.getDescription());
+		obj.addProperty("category", src.getCategory());
+		obj.addProperty("incomplete", src.isIncomplete());
+		obj.add("amount", context.serialize(src.getAmount(), Money.class));
+		obj.add("date", context.serialize(src.getDate(), Date.class));
+		
+		Uri receiptUri = src.getReceiptUri();
+		if (receiptUri != null) {
+			InputStream inputStream;
+			try {
+				inputStream = new FileInputStream(receiptUri.getPath());
+				byte[] buffer = new byte[inputStream.available()];
+				inputStream.read(buffer);
+				inputStream.close();
+				
+				String base64Str = Base64.encodeToString(buffer, Base64.DEFAULT);
+				obj.addProperty("receipt_base64", base64Str);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		return obj;
 	}
 }

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
@@ -1,0 +1,38 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Serializes an {@link ExpenseItem} to JSON.
+ */
+public class ExpenseItemJSONSerializer implements JsonSerializer<ExpenseItem> {
+
+	/* (non-Javadoc)
+	 * @see com.google.gson.JsonSerializer#serialize(java.lang.Object, java.lang.reflect.Type, com.google.gson.JsonSerializationContext)
+	 */
+	@Override
+	public JsonElement serialize(ExpenseItem src, Type typeOfSrc, JsonSerializationContext context) {
+		return null;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
@@ -49,7 +49,10 @@ public class ExpenseItemJSONSerializer implements JsonSerializer<ExpenseItem> {
 		obj.addProperty("category", src.getCategory());
 		obj.addProperty("incomplete", src.isIncomplete());
 		obj.add("amount", context.serialize(src.getAmount(), Money.class));
-		obj.add("date", context.serialize(src.getDate(), Date.class));
+		Date date = src.getDate();
+		if (date != null) {
+			obj.addProperty("date", date.getTime());
+		}
 		
 		Uri receiptUri = src.getReceiptUri();
 		if (receiptUri != null) {

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemJSONSerializer.java
@@ -49,10 +49,7 @@ public class ExpenseItemJSONSerializer implements JsonSerializer<ExpenseItem> {
 		obj.addProperty("category", src.getCategory());
 		obj.addProperty("incomplete", src.isIncomplete());
 		obj.add("amount", context.serialize(src.getAmount(), Money.class));
-		Date date = src.getDate();
-		if (date != null) {
-			obj.addProperty("date", date.getTime());
-		}
+		obj.add("date", context.serialize(src.getDate(), Date.class));
 		
 		Uri receiptUri = src.getReceiptUri();
 		if (receiptUri != null) {

--- a/Team9Project/src/com/indragie/cmput301as1/ExpenseItemViewConfigurator.java
+++ b/Team9Project/src/com/indragie/cmput301as1/ExpenseItemViewConfigurator.java
@@ -71,7 +71,7 @@ public class ExpenseItemViewConfigurator implements ViewConfigurator<ExpenseClai
 		
 		ImageView receiptImageView = (ImageView)view.findViewById(R.id.iv_receipt_icon);
 		receiptImageView.setVisibility(View.INVISIBLE);
-		if (item.getReceiptPath() != null) {
+		if (item.getReceiptUri() != null) {
 			receiptImageView.setVisibility(View.VISIBLE);
 		}
 		

--- a/Team9Project/src/com/indragie/cmput301as1/JSONHelpers.java
+++ b/Team9Project/src/com/indragie/cmput301as1/JSONHelpers.java
@@ -1,0 +1,96 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Helper functions for working with JSON data with Gson.
+ */
+public class JSONHelpers {
+	/**
+	 * Gets the value of the JSON element as a string if possible.
+	 * @param element The JSON element.
+	 * @return A string if the JSON element was a string, or
+	 * null otherwise.
+	 */
+	public static String getStringIfPossible(JsonElement element) {
+		if (element == null) return null;
+		
+		if (element.isJsonPrimitive()) {
+			JsonPrimitive primitive = element.getAsJsonPrimitive();
+			if (primitive.isString()) {
+				return primitive.getAsString();
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * Gets the value of the JSON element as a boolean if possible.
+	 * @param element The JSON element.
+	 * @return A string if the JSON element was a boolean, or
+	 * false otherwise.
+	 */
+	public static boolean getBooleanIfPossible(JsonElement element) {
+		if (element == null) return false;
+		
+		if (element.isJsonPrimitive()) {
+			JsonPrimitive primitive = element.getAsJsonPrimitive();
+			if (primitive.isBoolean()) {
+				return primitive.getAsBoolean();
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Gets the value of the JSON element as a long if possible.
+	 * @param element The JSON element.
+	 * @return A string if the JSON element was a long, or
+	 * 0 otherwise.
+	 */
+	public static long getLongIfPossible(JsonElement element) {
+		if (element == null) return 0;
+		
+		if (element.isJsonPrimitive()) {
+			JsonPrimitive primitive = element.getAsJsonPrimitive();
+			if (primitive.isNumber()) {
+				return primitive.getAsLong();
+			}
+		}
+		return 0;
+	}
+	
+	/**
+	 * Gets the value of the JSON element as a JSON object if possible.
+	 * @param element The JSON element.
+	 * @return A string if the JSON element was a JSON object, or
+	 * null otherwise.
+	 */
+	public static JsonObject getJsonObjectIfPossible(JsonElement element) {
+		if (element == null) return null;
+		
+		if (element.isJsonObject()) {
+			return element.getAsJsonObject();
+		}
+		return null;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/Session.java
+++ b/Team9Project/src/com/indragie/cmput301as1/Session.java
@@ -19,6 +19,8 @@ package com.indragie.cmput301as1;
 import java.io.IOException;
 import java.util.List;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 
@@ -105,7 +107,7 @@ public class Session implements TypedObserver<CollectionMutation<ExpenseClaim>> 
 	/**
 	 * Used to make API calls to the ElasticSearch servers.
 	 */
-	private ElasticSearchAPIClient apiClient = new ElasticSearchAPIClient(ElasticSearchConfiguration.getBaseURL());
+	private ElasticSearchAPIClient apiClient;
 	
 	//================================================================================
 	// Constructors
@@ -128,6 +130,13 @@ public class Session implements TypedObserver<CollectionMutation<ExpenseClaim>> 
 		
 		pushQueue = new ElasticSearchQueue<ExpenseClaim>(context);
 		pullQueue = new ElasticSearchQueue<List<ExpenseClaim>>(context);
+		
+		GsonBuilder builder = new GsonBuilder();
+		builder.registerTypeAdapter(ExpenseItem.class, new ExpenseItemJSONSerializer());
+		builder.registerTypeAdapter(ExpenseItem.class, new ExpenseItemJSONDeserializer(new ExpenseItemReceiptController()));
+		Gson gson = builder.create();
+		
+		apiClient = new ElasticSearchAPIClient(ElasticSearchConfiguration.getBaseURL(), gson);
 	}
 	
 	/**

--- a/Team9Project/src/com/indragie/cmput301as1/Session.java
+++ b/Team9Project/src/com/indragie/cmput301as1/Session.java
@@ -17,6 +17,7 @@
 package com.indragie.cmput301as1;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 
 import com.google.gson.Gson;
@@ -132,6 +133,8 @@ public class Session implements TypedObserver<CollectionMutation<ExpenseClaim>> 
 		pullQueue = new ElasticSearchQueue<List<ExpenseClaim>>(context);
 		
 		GsonBuilder builder = new GsonBuilder();
+		builder.registerTypeAdapter(Date.class, new DateJSONSerializer());
+		builder.registerTypeAdapter(Date.class, new DateJSONDeserializer());
 		builder.registerTypeAdapter(ExpenseItem.class, new ExpenseItemJSONSerializer());
 		builder.registerTypeAdapter(ExpenseItem.class, new ExpenseItemJSONDeserializer(new ExpenseItemReceiptController()));
 		Gson gson = builder.create();

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
@@ -73,7 +73,7 @@ public class ExpenseItemJSONSerializationTests extends ActivityTestCase {
 		
 		// Serialize, then deserialize and check if the objects are the same
 		ExpenseItemJSONSerializer serializer = new ExpenseItemJSONSerializer();
-		ExpenseItemJSONDeserializer deserializer = new ExpenseItemJSONDeserializer();
+		ExpenseItemJSONDeserializer deserializer = new ExpenseItemJSONDeserializer(controller);
 		GsonBuilder builder = new GsonBuilder();
 		builder.registerTypeAdapter(ExpenseItem.class, serializer);
 		builder.registerTypeAdapter(ExpenseItem.class, deserializer);

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
@@ -74,13 +74,11 @@ public class ExpenseItemJSONSerializationTests extends ActivityTestCase {
 		item.setReceiptUri(receiptUri);
 		
 		// Serialize, then deserialize and check if the objects are the same
-		ExpenseItemJSONSerializer serializer = new ExpenseItemJSONSerializer();
-		ExpenseItemJSONDeserializer deserializer = new ExpenseItemJSONDeserializer(controller);
 		GsonBuilder builder = new GsonBuilder();
 		builder.registerTypeAdapter(Date.class, new DateJSONSerializer());
 		builder.registerTypeAdapter(Date.class, new DateJSONDeserializer());
-		builder.registerTypeAdapter(ExpenseItem.class, serializer);
-		builder.registerTypeAdapter(ExpenseItem.class, deserializer);
+		builder.registerTypeAdapter(ExpenseItem.class, new ExpenseItemJSONSerializer());
+		builder.registerTypeAdapter(ExpenseItem.class, new ExpenseItemJSONDeserializer(controller));
 		Gson gson = builder.create();
 		
 		String json = gson.toJson(item);

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
@@ -35,6 +35,8 @@ import android.test.ActivityTestCase;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.indragie.cmput301as1.DateJSONDeserializer;
+import com.indragie.cmput301as1.DateJSONSerializer;
 import com.indragie.cmput301as1.ExpenseItem;
 import com.indragie.cmput301as1.ExpenseItemJSONDeserializer;
 import com.indragie.cmput301as1.ExpenseItemJSONSerializer;
@@ -75,6 +77,8 @@ public class ExpenseItemJSONSerializationTests extends ActivityTestCase {
 		ExpenseItemJSONSerializer serializer = new ExpenseItemJSONSerializer();
 		ExpenseItemJSONDeserializer deserializer = new ExpenseItemJSONDeserializer(controller);
 		GsonBuilder builder = new GsonBuilder();
+		builder.registerTypeAdapter(Date.class, new DateJSONSerializer());
+		builder.registerTypeAdapter(Date.class, new DateJSONDeserializer());
 		builder.registerTypeAdapter(ExpenseItem.class, serializer);
 		builder.registerTypeAdapter(ExpenseItem.class, deserializer);
 		Gson gson = builder.create();

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
@@ -45,6 +45,7 @@ public class ExpenseItemJSONSerializationTests extends ActivityTestCase {
 	public void testSerializationAndDeserialization() throws IOException {
 		ExpenseItem item = 
 				new ExpenseItem("Taxi", "Taxi from airport", "ground transportation", Money.of(CurrencyUnit.CAD, 60.0), new Date());
+		item.setIncomplete(true);
 		Resources resources = getInstrumentation().getContext().getResources();
 		ExpenseItemReceiptController controller = new ExpenseItemReceiptController();
 		

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemJSONSerializationTests.java
@@ -1,0 +1,102 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.comput301as1.test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Date;
+
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+
+import android.content.res.Resources;
+import android.net.Uri;
+import android.test.ActivityTestCase;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.indragie.cmput301as1.ExpenseItem;
+import com.indragie.cmput301as1.ExpenseItemJSONDeserializer;
+import com.indragie.cmput301as1.ExpenseItemJSONSerializer;
+import com.indragie.cmput301as1.ExpenseItemReceiptController;
+import com.indragie.cmput301as1.test.R;
+
+public class ExpenseItemJSONSerializationTests extends ActivityTestCase {
+	public void testSerializationAndDeserialization() throws IOException {
+		ExpenseItem item = 
+				new ExpenseItem("Taxi", "Taxi from airport", "ground transportation", Money.of(CurrencyUnit.CAD, 60.0), new Date());
+		Resources resources = getInstrumentation().getContext().getResources();
+		ExpenseItemReceiptController controller = new ExpenseItemReceiptController();
+		
+		// Read the test image into memory.
+		// From http://www.baeldung.com/convert-input-stream-to-a-file
+		//
+		// Test image is public domain.
+		// Source: https://www.flickr.com/photos/surveying/16819186299/in/pool-publicdomain
+		InputStream inputStream = resources.openRawResource(R.raw.test_image);
+		byte[] buffer = new byte[inputStream.available()];
+		inputStream.read(buffer);
+		inputStream.close();
+		
+		// Write the original file contents to disk.
+		Uri receiptUri = controller.constructNewReceiptImageUri();
+		File receiptFile = new File(receiptUri.getPath());
+		OutputStream outputStream = new FileOutputStream(receiptFile);
+		outputStream.write(buffer);
+		outputStream.flush();
+		outputStream.close();
+		
+		// Post-process the image.
+		assertTrue(controller.postProcessReceiptImage(receiptUri));
+		item.setReceiptUri(receiptUri);
+		
+		// Serialize, then deserialize and check if the objects are the same
+		ExpenseItemJSONSerializer serializer = new ExpenseItemJSONSerializer();
+		ExpenseItemJSONDeserializer deserializer = new ExpenseItemJSONDeserializer();
+		GsonBuilder builder = new GsonBuilder();
+		builder.registerTypeAdapter(ExpenseItem.class, serializer);
+		builder.registerTypeAdapter(ExpenseItem.class, deserializer);
+		Gson gson = builder.create();
+		
+		String json = gson.toJson(item);
+		ExpenseItem deserializedItem = gson.fromJson(json, ExpenseItem.class);
+		assertEquals(item, deserializedItem);
+		
+		// Since ExpenseItem.equals() doesn't check the receipts, we have to manually
+		// compare the receipt file data.
+		Uri deserializedUri = deserializedItem.getReceiptUri();
+		assertNotNull(deserializedUri);
+		
+		InputStream originalInputStream = new FileInputStream(receiptUri.getPath());
+		byte[] originalBuffer = new byte[originalInputStream.available()];
+		originalInputStream.read(buffer);
+		originalInputStream.close();
+		
+		InputStream deserializedInputStream = new FileInputStream(deserializedUri.getPath());
+		byte[] deserializedBuffer = new byte[deserializedInputStream.available()];
+		deserializedInputStream.read(buffer);
+		deserializedInputStream.close();
+		
+		assertTrue(Arrays.equals(originalBuffer, deserializedBuffer));
+	}
+}

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemReceiptControllerTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/ExpenseItemReceiptControllerTests.java
@@ -61,6 +61,7 @@ public class ExpenseItemReceiptControllerTests extends ActivityTestCase {
 		InputStream inputStream = resources.openRawResource(R.raw.test_image);
 		byte[] buffer = new byte[inputStream.available()];
 		inputStream.read(buffer);
+		inputStream.close();
 		
 		// Write the original file contents to disk.
 		Uri receiptUri = controller.constructNewReceiptImageUri();


### PR DESCRIPTION
Store receipt data on ElasticSearch as base64 encoded strings. Used the following HTTP request to disable indexing for the receipt data in our index:

```
curl -X "PUT" "http://cmput301.softwareprocess.es:8080/cmput301w15t09/_mapping/expense_claim" \
    -d $'{
    "expense_claim" : {
        "properties" : {
            "items" : {
                "type" : "nested",
                "properties": {
                    "receipt_base64": {
                        "type": "string",
                        "include_in_all": false,
                        "index": "no"
                    }
                }
            }
        }
    }
}'
```
