### PR TITLE
Better Date Serialization

### DIFF
--- a/Team9Project/src/com/indragie/cmput301as1/DateJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/DateJSONDeserializer.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 
 /**
  * Deserializes {@link Date} objects from JSON.
@@ -35,7 +36,12 @@ public class DateJSONDeserializer implements JsonDeserializer<Date> {
 	 */
 	@Override
 	public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-		// TODO Auto-generated method stub
+		if (json.isJsonPrimitive()) {
+			JsonPrimitive primitive = json.getAsJsonPrimitive();
+			if (primitive.isNumber()) {
+				return new Date(primitive.getAsLong());
+			}
+		}
 		return null;
 	}
 }

--- a/Team9Project/src/com/indragie/cmput301as1/DateJSONDeserializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/DateJSONDeserializer.java
@@ -1,0 +1,41 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * Deserializes {@link Date} objects from JSON.
+ */
+public class DateJSONDeserializer implements JsonDeserializer<Date> {
+	
+	/* (non-Javadoc)
+	 * @see com.google.gson.JsonDeserializer#deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext)
+	 */
+	@Override
+	public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/Team9Project/src/com/indragie/cmput301as1/DateJSONSerializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/DateJSONSerializer.java
@@ -35,6 +35,6 @@ public class DateJSONSerializer implements JsonSerializer<Date> {
 	 */
 	@Override
 	public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-		return null;
+		return new JsonPrimitive(src.getTime());
 	}
 }

--- a/Team9Project/src/com/indragie/cmput301as1/DateJSONSerializer.java
+++ b/Team9Project/src/com/indragie/cmput301as1/DateJSONSerializer.java
@@ -1,0 +1,40 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Serializes {@link Date} objects to JSON.
+ */
+public class DateJSONSerializer implements JsonSerializer<Date> {
+
+	/* (non-Javadoc)
+	 * @see com.google.gson.JsonSerializer#serialize(java.lang.Object, java.lang.reflect.Type, com.google.gson.JsonSerializationContext)
+	 */
+	@Override
+	public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+		return null;
+	}
+}

--- a/Team9ProjectTests/src/com/indragie/comput301as1/test/DateJSONSerializationTests.java
+++ b/Team9ProjectTests/src/com/indragie/comput301as1/test/DateJSONSerializationTests.java
@@ -1,0 +1,41 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.comput301as1.test;
+
+import java.util.Date;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.indragie.cmput301as1.DateJSONDeserializer;
+import com.indragie.cmput301as1.DateJSONSerializer;
+
+import junit.framework.TestCase;
+
+public class DateJSONSerializationTests extends TestCase {
+	public void testSerializationAndDeserialization() {
+		GsonBuilder builder = new GsonBuilder();
+		builder.registerTypeAdapter(Date.class, new DateJSONSerializer());
+		builder.registerTypeAdapter(Date.class, new DateJSONDeserializer());
+		Gson gson = builder.create();
+		
+		Date date = new Date();
+		String json = gson.toJson(date, Date.class);
+		Date deserializedDate = gson.fromJson(json, Date.class);
+		assertEquals(date, deserializedDate);
+	}
+}


### PR DESCRIPTION
Gson's default date serialization and deserialization stores the date as a string, which leads to incorrect results that are off by a few seconds when deserialized. This implements a custom serializer and deserializer that directly stores the `long` representation of the `Date` object to avoid that issue.
