### PR TITLE
Parent activity for place picker

### DIFF
--- a/Team9Project/gen/com/indragie/cmput301as1/R.java
+++ b/Team9Project/gen/com/indragie/cmput301as1/R.java
@@ -782,6 +782,9 @@ containing a value of this type.
         public static final int name_hint=0x7f060042;
         public static final int no_destinations=0x7f06003c;
         public static final int no_expenses=0x7f06003b;
+        /**  PlacePickerParentActivity 
+         */
+        public static final int places_unavailable_error=0x7f060071;
         public static final int sort_order=0x7f060054;
         public static final int sort_type=0x7f060053;
         public static final int start_label=0x7f060044;

--- a/Team9Project/res/values/strings.xml
+++ b/Team9Project/res/values/strings.xml
@@ -102,4 +102,7 @@
 
     <!--  Tag{Add,Edit}ToClaimActivity -->
     <string name="title_activity_tag_edit_to_claim">TagEditToClaimActivity</string>
+    
+    <!-- PlacePickerParentActivity -->
+    <string name="places_unavailable_error">Unable to connect to Google Places</string>
 </resources>

--- a/Team9Project/src/com/indragie/cmput301as1/PlacePickerParentActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/PlacePickerParentActivity.java
@@ -53,6 +53,11 @@ public class PlacePickerParentActivity extends Activity {
 		 * @param place The place that was picked.
 		 */
 		public void onPlacePicked(Place place);
+		
+		/**
+		 * Called when the place picker action is canceled.
+		 */
+		public void onPlacePickerCanceled();
 	}
 	
 	//================================================================================
@@ -97,6 +102,8 @@ public class PlacePickerParentActivity extends Activity {
 			if (resultCode == RESULT_OK) {
 				final Place place = PlacePicker.getPlace(data, this);
 				placePickedListener.onPlacePicked(place);
+			} else {
+				placePickedListener.onPlacePickerCanceled();
 			}
 			placePickedListener = null;
 		} else {

--- a/Team9Project/src/com/indragie/cmput301as1/PlacePickerParentActivity.java
+++ b/Team9Project/src/com/indragie/cmput301as1/PlacePickerParentActivity.java
@@ -1,0 +1,118 @@
+/* 
+ * Copyright (C) 2015 Indragie Karunaratne
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.indragie.cmput301as1;
+
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.location.places.Place;
+import com.google.android.gms.location.places.ui.PlacePicker;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.widget.Toast;
+
+/**
+ * Parent activity that provides a simple abstraction for picking
+ * a place using the Google Place Picker API.
+ */
+public class PlacePickerParentActivity extends Activity {
+	//================================================================================
+	// Constants
+	//================================================================================
+	
+	/**
+	 * Request code for opening the place picker activity.
+	 */
+	private static final int PLACE_PICKER_REQUEST_CODE = 50;
+	
+	//================================================================================
+	// Interfaces
+	//================================================================================
+	
+	/**
+	 * Listener that is called when a place is picked.
+	 */
+	public interface OnPlacePickedListener {
+		/**
+		 * Called when a place is picked.
+		 * @param place The place that was picked.
+		 */
+		public void onPlacePicked(Place place);
+	}
+	
+	//================================================================================
+	// Properties
+	//================================================================================
+	
+	/**
+	 * Listener that is called when a place is picked.
+	 */
+	private OnPlacePickedListener placePickedListener;
+	
+	//================================================================================
+	// API
+	//================================================================================
+	
+	/**
+	 * Opens the place picker activity.
+	 * @param placePickedListener Listener that is called when a place is picked.
+	 */
+	public void openPlacePicker(OnPlacePickedListener placePickedListener) {
+		try {
+			PlacePicker.IntentBuilder builder = new PlacePicker.IntentBuilder();
+			Intent intent = builder.build(this);
+			this.placePickedListener = placePickedListener;
+			startActivityForResult(intent, PLACE_PICKER_REQUEST_CODE);
+		} catch (GooglePlayServicesRepairableException e) {
+			e.printStackTrace();
+			showUnableToConnectToast();
+		} catch (GooglePlayServicesNotAvailableException e) {
+			e.printStackTrace();
+			showUnableToConnectToast();
+		}
+	}
+	
+	//================================================================================
+	// Activity
+	//================================================================================
+	
+	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+		if (requestCode == PLACE_PICKER_REQUEST_CODE) {
+			if (resultCode == RESULT_OK) {
+				final Place place = PlacePicker.getPlace(data, this);
+				placePickedListener.onPlacePicked(place);
+			}
+			placePickedListener = null;
+		} else {
+			super.onActivityResult(requestCode, resultCode, data);
+		}
+	}
+	
+	//================================================================================
+	// Private
+	//================================================================================
+	
+	/**
+	 * Shows a toast that indicates to the user that the application was
+	 * unable to connect to the Google Places API.
+	 */
+	private void showUnableToConnectToast() {
+		Toast.makeText(this, R.string.places_unavailable_error, Toast.LENGTH_LONG).show();
+	}
+}


### PR DESCRIPTION
This PR implements `PlacePickerParentActivity`, which is intended to simplify the task of implementing an activity that allows the user to choose a location for one or more of its fields (e.g. in the destination activity or the expense item activity).

Here's an example of how this could be used:

``` java
public class DestinationActivity extends PlacePickerParentActivity {
    ...
    @Override
    protected void onCreate(Bundle savedInstanceState) {
        ...
        final EditText locationField = ...;
        final OnPlacePickedListener listener = new OnPlacePickedListener() {
            @Override
            public void onPlacePickerCanceled() {
                locationField.clearFocus();
            }

            @Override
            public void onPlacePicked(Place place) {
                locationField.setText(place.getName() + "\n" + place.getAddress());
                locationField.clearFocus();

                Geolocation location = new Geolocation(place.getLatLng());
                // You can now do something with this location, like assign
                // it to a destination.
            }
        };

        locationField.setOnFocusChangeListener(new View.OnFocusChangeListener() {
            @Override
            public void onFocusChange(View v, boolean hasFocus) {
                if (hasFocus) {
                    openPlacePicker(listener);
                }
            }
        });
    }
}
```
